### PR TITLE
Example of using bumpver to increment version strings

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,23 @@
+# Maintainer Notes
+
+These are some notes on common operations only important to package maintainers.
+
+## Versioning
+
+We use `bumpver` to increment all of our version strings. This removes the
+common headaches around trying to write the version string once and
+simultaneously avoid cyclical imports. It also automates versioning non-Python
+sources.
+
+To increment manually:
+
+    bumpver update --set-version="1.1.0"
+
+You can also test first:
+
+    bumpver update --dry --set-version="1.1.0"
+
+And you can even try to leave it to `bumpver` to decide your new version number,
+but incrementing only one part of the version:
+
+    bumpver update --patch

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,8 +1,8 @@
-# Maintainer Notes
+Development
+===========
 
-These are some notes on common operations only important to package maintainers.
-
-## Versioning
+Versioning
+----------
 
 We use `bumpver` to increment all of our version strings. This removes the
 common headaches around trying to write the version string once and
@@ -11,13 +11,19 @@ sources.
 
 To increment manually:
 
-    bumpver update --set-version="1.1.0"
+.. code:: console
+
+    % bumpver update --set-version="1.1.0"
 
 You can also test first:
 
-    bumpver update --dry --set-version="1.1.0"
+.. code:: console
+
+    % bumpver update --dry --set-version="1.1.0"
 
 And you can even try to leave it to `bumpver` to decide your new version number,
 but incrementing only one part of the version:
 
-    bumpver update --patch
+.. code:: console
+
+    % bumpver update --patch

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -4,7 +4,7 @@ Development
 Versioning
 ----------
 
-We use `bumpver` to increment all of our version strings. This removes the
+We use ``bumpver`` to increment all of our version strings. This removes the
 common headaches around trying to write the version string once and
 simultaneously avoid cyclical imports. It also automates versioning non-Python
 sources.
@@ -21,7 +21,7 @@ You can also test first:
 
     % bumpver update --dry --set-version="1.1.0"
 
-And you can even try to leave it to `bumpver` to decide your new version number,
+And you can even try to leave it to ``bumpver`` to decide your new version number,
 but incrementing only one part of the version:
 
 .. code:: console

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ Build multiple Sphinx projects from a single repository on
    advanced-usage
    limitations
    implementation
+   development
 
 Indices and tables
 ==================

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,3 +25,21 @@ python_requires = >=3.7
 
 [options.packages.find]
 include = multiproject
+
+[bumpver]
+current_version = "1.0.0rc1"
+version_pattern = "MAJOR.MINOR.PATCH[TAGNUM]"
+commit_message = "Bump version {old_version} -> {new_version}"
+commit = False
+tag = False
+push = False
+
+[bumpver:file_patterns]
+setup.cfg =
+    version = "{version}"
+docs/conf.py =
+    release = "{version}"
+multiproject/extension.py = 
+    __version__ = "{version}"
+multiproject/__init__.py = 
+    __version__ = "{version}"

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
 [testenv]
 deps =
   pytest
+  Jinja2<3.1
   .
   sphinx3: sphinx~=3.0
   sphinx40: sphinx~=4.0.0


### PR DESCRIPTION
Instead of importing and dealing with eventual cyclical imports, this
uses bumpver to increment these values everywhere.

We've used bumpversion/bump2version in the past, and it's a bit more
opinionated and hard to configure. This is a much nicer tool. I'll be
raising switching our use to this tool on more repos.