### PR TITLE
Bug fix: Return updated 'app.srcdir' as a Path object instead of as a 'str' object

### DIFF
--- a/multiproject/extension.py
+++ b/multiproject/extension.py
@@ -34,7 +34,9 @@ def _override_srdir(app, config):
     new_srcdir = Path(options.get("path", project))
     if not new_srcdir.is_absolute():
         new_srcdir = original_srcdir / new_srcdir
-    app.srcdir = str(new_srcdir.resolve())
+    # app.srcdir is a Path object and not 'str' in newer versions of Sphinx
+    # app.srcdir = str(new_srcdir.resolve())
+    app.srcdir = new_srcdir.resolve()
 
 
 def _override_config(app, config):


### PR DESCRIPTION
Latest Sphinx version expects 'srcdir' to be a Path rather than a 'str'.

**Sample error caused by the bug**:
`copying images... [100%] all-clouds-how-to/check-cve-on-instance-images/0_oscap_oval_cve_scan_report.png 
Exception occurred:  File "/xxx/ubuntu-cloud-docs/.sphinx/venv/lib/python3.10/site-packages/sphinx/builders/html/__init__.py", line 780, in copy_image_files
    self.srcdir / src, err)

TypeError: unsupported operand type(s) for /: 'str' and 'str'`

**Occurs when** sphinx-multiproject extension is used and images are included in .rst files