### PR TITLE
Support latest versions of Sphinx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,48 +4,41 @@ commands:
   run-tox:
     description: "Run tox"
     parameters:
-      version:
+      envs:
         type: string
-      sphinx-version:
-        type: string
-        default: "4,5,6,7,8,latest"
+        default: "sphinx4,sphinx5,sphinx6,sphinx7,sphinx8,sphinxlatest"
     steps:
       - checkout
       - run: pip install --user tox
       - run:
-          command: tox -e "<<parameters.version>>-sphinx{<<parameters.sphinx-version>>}"
+          command: tox -e "{<<parameters.envs>>}"
 
 jobs:
   py39:
     docker:
       - image: 'cimg/python:3.9'
     steps:
-      - run-tox:
-          version: py39
+      - run-tox
   py310:
     docker:
       - image: 'cimg/python:3.10'
     steps:
-      - run-tox:
-          version: py310
+      - run-tox
   py311:
     docker:
       - image: 'cimg/python:3.11'
     steps:
-      - run-tox:
-          version: py311
+      - run-tox
   py312:
     docker:
       - image: 'cimg/python:3.12'
     steps:
-      - run-tox:
-          version: py312
+      - run-tox
   py313:
     docker:
       - image: 'cimg/python:3.13'
     steps:
-      - run-tox:
-          version: py313
+      - run-tox
   checks:
     docker:
       - image: 'cimg/python:3.13'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ commands:
         type: string
       sphinx-version:
         type: string
-        default: "3,40,41,42,43,44,latest"
+        default: "4,5,6,7,8,latest"
     steps:
       - checkout
       - run: pip install --user tox
@@ -16,18 +16,6 @@ commands:
           command: tox -e "<<parameters.version>>-sphinx{<<parameters.sphinx-version>>}"
 
 jobs:
-  py37:
-    docker:
-      - image: 'cimg/python:3.7'
-    steps:
-      - run-tox:
-          version: py37
-  py38:
-    docker:
-      - image: 'cimg/python:3.8'
-    steps:
-      - run-tox:
-          version: py38
   py39:
     docker:
       - image: 'cimg/python:3.9'
@@ -40,10 +28,27 @@ jobs:
     steps:
       - run-tox:
           version: py310
-          sphinx-version: 42,43,44,latest
+  py311:
+    docker:
+      - image: 'cimg/python:3.11'
+    steps:
+      - run-tox:
+          version: py311
+  py312:
+    docker:
+      - image: 'cimg/python:3.12'
+    steps:
+      - run-tox:
+          version: py312
+  py313:
+    docker:
+      - image: 'cimg/python:3.13'
+    steps:
+      - run-tox:
+          version: py313
   checks:
     docker:
-      - image: 'cimg/python:3.10'
+      - image: 'cimg/python:3.13'
     steps:
       - checkout
       - run: pip install --user tox
@@ -54,7 +59,8 @@ workflows:
   tests:
     jobs:
       - checks
+      - py313
+      - py312
+      - py311
       - py310
       - py39
-      - py38
-      - py37

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,11 +34,6 @@ jobs:
       - image: 'cimg/python:3.12'
     steps:
       - run-tox
-  py313:
-    docker:
-      - image: 'cimg/python:3.13'
-    steps:
-      - run-tox
   checks:
     docker:
       - image: 'cimg/python:3.13'
@@ -52,7 +47,6 @@ workflows:
   tests:
     jobs:
       - checks
-      - py313
       - py312
       - py311
       - py310

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ commands:
     parameters:
       envs:
         type: string
-        default: "sphinx4,sphinx5,sphinx6,sphinx7,sphinx8,sphinxlatest"
+        default: "sphinx5,sphinx6,sphinx7,sphinx8,sphinxlatest"
     steps:
       - checkout
       - run: pip install --user tox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ commands:
     parameters:
       envs:
         type: string
-        default: "sphinx5,sphinx6,sphinx7,sphinx8,sphinxlatest"
+        default: "sphinx6,sphinx7,sphinx8,sphinxlatest"
     steps:
       - checkout
       - run: pip install --user tox
@@ -35,6 +35,11 @@ jobs:
       - image: 'cimg/python:3.12'
     steps:
       - run-tox
+  py313:
+    docker:
+      - image: 'cimg/python:3.13'
+    steps:
+      - run-tox
   checks:
     docker:
       - image: 'cimg/python:3.13'
@@ -48,6 +53,7 @@ workflows:
   tests:
     jobs:
       - checks
+      - py313
       - py312
       - py311
       - py310

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ commands:
       - checkout
       - run: pip install --user tox
       - run:
-          command: tox -e "{<<parameters.envs>>}"
+          command: tox -e "<<parameters.envs>>"
 
 jobs:
   py39:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,8 @@ jobs:
     docker:
       - image: 'cimg/python:3.9'
     steps:
-      - run-tox
+      - run-tox:
+          envs: "sphinx5,sphinx6,sphinx7"
   py310:
     docker:
       - image: 'cimg/python:3.10'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==4.4.0
-sphinx-rtd-theme==1.0.0
+sphinx~=8.0
+sphinx-rtd-theme==3.0.1

--- a/multiproject/extension.py
+++ b/multiproject/extension.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from sphinx.config import CONFIG_FILENAME, eval_config_file
 from sphinx.util import logging
+from sphinx.util._pathlib import _StrPath
 
 from .utils import get_project
 
@@ -34,7 +35,8 @@ def _override_srdir(app, config):
     new_srcdir = Path(options.get("path", project))
     if not new_srcdir.is_absolute():
         new_srcdir = original_srcdir / new_srcdir
-    app.srcdir = str(new_srcdir.resolve())
+    # Sphinx uses a custom Path class for the srcdir.
+    app.srcdir = _StrPath(new_srcdir.resolve())
 
 
 def _override_config(app, config):

--- a/multiproject/extension.py
+++ b/multiproject/extension.py
@@ -1,8 +1,15 @@
 from pathlib import Path
 
+from sphinx import version_info as sphinx_version
 from sphinx.config import CONFIG_FILENAME, eval_config_file
 from sphinx.util import logging
-from sphinx.util._pathlib import _StrPath
+
+# Sphinx versions previous to 7.2 used a string for the srcdir,
+# while newer versions use a custom Path class.
+if sphinx_version >= (7, 2, 0):
+    from sphinx.util._pathlib import _StrPath as SphinxSrcDir
+else:
+    SphinxSrcDir = str
 
 from .utils import get_project
 
@@ -35,8 +42,7 @@ def _override_srdir(app, config):
     new_srcdir = Path(options.get("path", project))
     if not new_srcdir.is_absolute():
         new_srcdir = original_srcdir / new_srcdir
-    # Sphinx uses a custom Path class for the srcdir.
-    app.srcdir = _StrPath(new_srcdir.resolve())
+    app.srcdir = SphinxSrcDir(new_srcdir.resolve())
 
 
 def _override_config(app, config):

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,7 +1,15 @@
 from unittest import mock
 
 import pytest
-from pathlib import Path
+from sphinx import version_info as sphinx_version
+
+# Sphinx versions previous to 7.2 used a custom
+# Path class for the srcdir in tests, while newer versions
+# use a plain Path class.
+if sphinx_version >= (7, 2, 0):
+    from pathlib import Path
+else:
+    from sphinx.testing.path import path as Path
 
 basedir = Path(__file__).parent / "examples"
 

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -20,7 +20,7 @@ class TestExtension:
         assert list(app.config.multiproject_projects.keys())[0] == "api"
         app.build()
         expected_srcdir = basedir / "basic/api"
-        assert app.srcdir == str(expected_srcdir)
+        assert str(app.srcdir) == str(expected_srcdir)
         out = (Path(app.outdir) / "index.html").read_text()
         assert "API documentation" in out
 
@@ -37,7 +37,7 @@ class TestExtension:
         app = make_app("html", srcdir=basedir / "basic")
         app.build()
         expected_srcdir = basedir / "basic" / project
-        assert app.srcdir == str(expected_srcdir)
+        assert str(app.srcdir) == str(expected_srcdir)
         out = (Path(app.outdir) / "index.html").read_text()
         assert expected_text in out
 
@@ -82,7 +82,7 @@ class TestExtension:
         app.build()
 
         expected_srcdir = basedir / "basic/user"
-        assert app.srcdir == str(expected_srcdir)
+        assert str(app.srcdir) == str(expected_srcdir)
 
         out = (Path(app.outdir) / "index.html").read_text()
         assert "User documentation" in out
@@ -150,7 +150,7 @@ class TestExtension:
         app.build()
 
         expected_srcdir = basedir / "conditional" / project
-        assert app.srcdir == str(expected_srcdir)
+        assert str(app.srcdir) == str(expected_srcdir)
 
         out = (Path(app.outdir) / "index.html").read_text()
         assert expected_text in out
@@ -195,7 +195,7 @@ class TestExtension:
         app.build()
 
         expected_srcdir = basedir / "multipleconfs" / project
-        assert app.srcdir == str(expected_srcdir)
+        assert str(app.srcdir) == str(expected_srcdir)
 
         out = (Path(app.outdir) / "index.html").read_text()
         assert expected_text in out

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 import pytest
-from sphinx.testing.path import path as Path
+from pathlib import Path
 
 basedir = Path(__file__).parent / "examples"
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,21 +2,18 @@
 isolated_build = True
 envlist =
   docs
-  py{37,38,39}-sphinx{3,40,41,42,43,44,latest}
-  py{310}-sphinx{42,43,44,latest}
+  py{39,310,311,312,313}-sphinx{4,5,6,7,8,latest}
   lint
 
 [testenv]
 deps =
   pytest
-  Jinja2<3.1
   .
-  sphinx3: sphinx~=3.0
-  sphinx40: sphinx~=4.0.0
-  sphinx41: sphinx~=4.1.0
-  sphinx42: sphinx~=4.2.0
-  sphinx43: sphinx~=4.3.0
-  sphinx44: sphinx~=4.4.0
+  sphinx4: sphinx~=4.0
+  sphinx5: sphinx~=5.0
+  sphinx6: sphinx~=6.0
+  sphinx7: sphinx~=7.0
+  sphinx8: sphinx~=8.0
   sphinxlatest: sphinx
   sphinxmaster: git+https://github.com/sphinx-doc/sphinx.git@master
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,14 +2,13 @@
 isolated_build = True
 envlist =
   docs
-  py{39,310,311,312,313}-sphinx{4,5,6,7,8,latest}
+  py{39,310,311,312,313}-sphinx{5,6,7,8,latest}
   lint
 
 [testenv]
 deps =
   pytest
   .
-  sphinx4: sphinx~=4.0
   sphinx5: sphinx~=5.0
   sphinx6: sphinx~=6.0
   sphinx7: sphinx~=7.0

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 isolated_build = True
 envlist =
   docs
-  py{39,310,311,312,313}-sphinx{5,6,7,8,latest}
+  py{39,310,311,312}-sphinx{5,6,7,8,latest}
   lint
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ isolated_build = True
 envlist =
   docs
   py39-sphinx{5,6,7}
-  py{310,311,312}-sphinx{5,6,7,8,latest}
+  py{310,311,312,313}-sphinx{6,7,8,latest}
   lint
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 isolated_build = True
 envlist =
   docs
-  py{39,310,311,312}-sphinx{5,6,7,8,latest}
+  py39-sphinx{5,6,7}
+  py{310,311,312}-sphinx{5,6,7,8,latest}
   lint
 
 [testenv]


### PR DESCRIPTION
Closes https://github.com/readthedocs/sphinx-multiproject/issues/9. This is also blocking us to upgrade the Sphinx version of our own docs at rtd.

Had to drop sphinx 3 and 4, as they no longer work by default, they have lots of incompatibilities with their own deps (sphinx-contrib). And also, the latest version of tox no longer expands environments :_